### PR TITLE
wax/common_minimal.sh: fix "[Linux: command not found"

### DIFF
--- a/wax/common_minimal.sh
+++ b/wax/common_minimal.sh
@@ -11,7 +11,8 @@
 
 # Determine script directory
 SCRIPT_DIR=$(dirname "$0")
-if [$(uname -s) -ne "Darwin"]; then
+# quotes and the spaces fixes ./common_minimal.sh: line 14: [Linux: command not found
+if [ "$(uname -s)" -ne "Darwin" ]; then
   PROG=$(basename "$0")
   : "${GPT:=cgpt}"
   : "${FUTILITY:=futility}"

--- a/wax/common_minimal.sh
+++ b/wax/common_minimal.sh
@@ -12,7 +12,7 @@
 # Determine script directory
 SCRIPT_DIR=$(dirname "$0")
 # quotes and the spaces fixes ./common_minimal.sh: line 14: [Linux: command not found
-if [ "$(uname -s)" -ne "Darwin" ]; then
+if [ "$(uname -s)" != "Darwin" ]; then
   PROG=$(basename "$0")
   : "${GPT:=cgpt}"
   : "${FUTILITY:=futility}"


### PR DESCRIPTION
For some reason, running a modified version of wax (not public yet) it returns "./common_minimal.sh: line 14: [Linux: command not found"