### PR TITLE
Update wax.sh

### DIFF
--- a/wax/wax.sh
+++ b/wax/wax.sh
@@ -53,8 +53,6 @@ echo "Creating loop device"
 loop=$(losetup -f)
 losetup -P ${loop} ${bin}
 
-lsblk
-
 echo "Making arch partition"
 mkfs.ext2 -L arch ${loop}p13 # ext2 so we can use skid protection features
 echo "Making ROOT mountable"

--- a/wax/wax.sh
+++ b/wax/wax.sh
@@ -75,7 +75,7 @@ cp -rv sh1mmer-assets mnt/usr/share/sh1mmer-assets
 cp -v sh1mmer-scripts/* mnt/usr/sbin/
 cp -v factory_install.sh mnt/usr/sbin/
 echo "Inserting firmware"
-wget "https://github.com/Netronome/linux-firmware/raw/master/iwlwifi-9000-pu-b0-jf-b0-41.ucode" >mnt/lib/firmware/iwlwifi-9000-pu-b0-jf-b0-41.ucode
+curl "https://github.com/Netronome/linux-firmware/raw/master/iwlwifi-9000-pu-b0-jf-b0-41.ucode" >mnt/lib/firmware/iwlwifi-9000-pu-b0-jf-b0-41.ucode
 echo "Brewing /etc/profile"
 
 echo 'PATH="$PATH:/usr/local/bin"' >>mnt/etc/profile

--- a/wax/wax.sh
+++ b/wax/wax.sh
@@ -33,25 +33,27 @@ fi
 
 echo "Expanding bin for 'arch' partition. this will take a while"
 
-dd if=/dev/zero bs=1G status=progress count=${CHROMEBREW_SIZE} >>$bin
+dd if=/dev/zero bs=1G status=progress count=${CHROMEBREW_SIZE} >>${bin}
 echo -ne "\a"
 # Fix corrupt gpt
-fdisk $bin <<EOF
+fdisk ${bin} <<EOF
 w
 
 EOF
 echo "Partitioning"
 # create new partition filling rest of disk
-fdisk $1 <<EOF
+fdisk ${1} <<EOF
 n
-
+13
 
 
 w
 EOF
 echo "Creating loop device"
 loop=$(losetup -f)
-losetup -P $loop $bin
+losetup -P ${loop} ${bin}
+
+lsblk
 
 echo "Making arch partition"
 mkfs.ext2 -L arch ${loop}p13 # ext2 so we can use skid protection features
@@ -75,7 +77,7 @@ cp -rv sh1mmer-assets mnt/usr/share/sh1mmer-assets
 cp -v sh1mmer-scripts/* mnt/usr/sbin/
 cp -v factory_install.sh mnt/usr/sbin/
 echo "Inserting firmware"
-curl "https://github.com/Netronome/linux-firmware/raw/master/iwlwifi-9000-pu-b0-jf-b0-41.ucode" >mnt/lib/firmware/iwlwifi-9000-pu-b0-jf-b0-41.ucode
+wget "https://github.com/Netronome/linux-firmware/raw/master/iwlwifi-9000-pu-b0-jf-b0-41.ucode" >mnt/lib/firmware/iwlwifi-9000-pu-b0-jf-b0-41.ucode
 echo "Brewing /etc/profile"
 
 echo 'PATH="$PATH:/usr/local/bin"' >>mnt/etc/profile


### PR DESCRIPTION
Changes:
1: When creating arch partition, tell `fdisk` to target partition 13, instead of the default 10. This fixes `The file /dev/{loop device}p13 does not exist and no size was specified.` since the 13th partition never gets created
2: Change `curl` to `wget`, since `curl` is sometimes not installed by default (at least on debian 12), while wget is basically universally installed on all distros.
3: Standardize variables to ${variable} because ocd lol