### PR TITLE
enforce .bin in buildlegacy

### DIFF
--- a/buildlegacy.html
+++ b/buildlegacy.html
@@ -29,9 +29,11 @@
                 event.returnValue = "";
             }
         }, {capture: true});
-        function start() {
-            $("#injector_output").value = "";
-            $("#hd_image").click();
+            function start() {
+                $("#injector_output").value = "";
+                const hdImageInput = $("#hd_image");
+                hdImageInput.setAttribute("accept", ".bin");
+                hdImageInput.click();
         }
         function startVM() {
             var emulator = window.emulator = new V86Starter({


### PR DESCRIPTION
simple code addition, this is to prevent people from accidentally using a .zip in the builder because for some reason it likes to continue with one

i have tested this works on my own fork of the builder on my site