### PR TITLE
Fix Wax on macOS

### DIFF
--- a/wax/wax_macos.sh
+++ b/wax/wax_macos.sh
@@ -45,7 +45,7 @@ n
 w
 EOF
 echo "Creating loop device"
-loop=$(hdiutil attach -nomount $bin | awk '{print $1;}' | head -n 1)
+loop=$(hdiutil attach -nomount -noverify -imagekey diskimage-class=CRawDiskImage $bin | awk '{print $1;}' | head -n 1) # found in https://en.wikipedia.org/wiki/Loop_device#Availability of all places
 
 echo "Making arch partition"
 mkfs.ext2 -L arch ${loop}s13 # ext2 so we can use skid protection features


### PR DESCRIPTION
Far from complete, attempt to get wax_macos.sh working for once. All testing/development will be done on x86 macOS 14.x.

TODO:

- [x] Fix `hdiutil attach` failing
- [ ] Get `fuse-ext2` working, somehow
- [ ] Fix any other bugs that arise
- [ ] Test it out