### PR TITLE
change default size to fix firmware failing to copy

### DIFF
--- a/wax/wax.sh
+++ b/wax/wax.sh
@@ -150,7 +150,7 @@ get_flags() {
 
 	DEFINE_string payload_dir "" "Custom main payload dir" ""
 
-	DEFINE_string sh1mmer_part_size "64M" "Partition size for payload(s)" "s"
+	DEFINE_string sh1mmer_part_size "128M" "Partition size for payload(s)" "s"
 
 	DEFINE_string extra_payload_dir "${SCRIPT_DIR}/payloads" "Extra payload dir" "e"
 


### PR DESCRIPTION
this fixes the need to manually pass `-s 128M` to avoid the following error
```bash
cp: error writing '/tmp/tmp.T2CQx7ZhYS/root/noarch/lib/firmware/iwlwifi-so-a0-gf-a0-83.ucode': No space left on device
cp -R "$FIRMWARE_DIR/"* "$MNT_SH1MMER/root/noarch/lib/firmware" failed with exit code 1. THIS IS A BUG, PLEASE REPORT!```